### PR TITLE
modifying gitmodules url to lbryum-server

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "lbryum-server"]
 	path = lbryum-server/lbryum-server
-	url = git@github.com:lbryio/lbryum-server.git
+	url = git://github.com/lbryio/lbryum-server.git


### PR DESCRIPTION
I'm not entirely sure if this is some git version issue? But the current url format doesn't work for the lbryum-sever submodule when I do a git clone --recursive , I'm using git version 2.5.0 
