### PR TITLE
Make a Downloads directory in lbrynet

### DIFF
--- a/lbrynet/Dockerfile
+++ b/lbrynet/Dockerfile
@@ -28,6 +28,8 @@ ADD data /data
 # lbrynet data should go in /data/lbrynet
 VOLUME /home/lbry/.lbrynet
 
+# lbrynet uses this as download folder
+RUN mkdir /root/Downloads
 
 # until Docker fixes the ability to change
 # the ownership of ADDed files, we have


### PR DESCRIPTION
lbrynet docker instance requires a Downloads directory to be made. Other wise you will see errors when publishing or downloading since the folder does not exist.