### PR TITLE
Fixed github path in README, to avoid permissions problems

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ no need to wait for claims or transactions to propogate.
 
 Clone the repo
 
-    git clone --recursive git@github.com:lbryio/lbry-in-a-box.git
+    git clone --recursive https://github.com/lbryio/lbry-in-a-box.git
     cd lbry-in-a-box
     docker-compose up
 
@@ -34,7 +34,7 @@ The external services can be found by looking at the `ports` listing in the
 In order to use the UI, there is some more steps to do. The lbry-in-a-box
 branch contains patches needed to get the UI to work.  Do something like:
 
-    git clone git@github.com:lbryio/lbry-web-ui.git
+    git clone https://github.com/lbryio/lbry-in-a-box.git
     git checkout lbry-in-a-box
     npm install
     ./node_modules/.bin/node-sass --output dist/css --sourcemap=none scss/


### PR DESCRIPTION
The git clone command wasn't working because of the wrong path